### PR TITLE
Хранение состояния диалога

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.jetbrains:annotations:25.0.0")
 
     implementation("com.typesafe:config:1.4.3")
+    implementation("org.json:json:20240303")
 
     implementation("org.slf4j:slf4j-api:2.0.16")
     implementation("org.apache.logging.log4j:log4j-core:2.24.0")

--- a/src/main/java/dev/metabrix/urfu/oopbot/storage/DataStorage.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/storage/DataStorage.java
@@ -47,6 +47,15 @@ public interface DataStorage extends AutoCloseable {
     @NotNull TaskStorage tasks();
 
     /**
+     * Возвращает хранилище состояний диалогов.
+     *
+     * @return хранилище состояний диалогов
+     * @since 1.1.0
+     * @author metabrix
+     */
+    @NotNull DialogStateStorage dialogStates();
+
+    /**
      * Проверяет, закрыто ли хранилище.
      *
      * @return {@code true}, если хранилище закрыто, иначе {@code false}

--- a/src/main/java/dev/metabrix/urfu/oopbot/storage/DialogStateStorage.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/storage/DialogStateStorage.java
@@ -1,0 +1,49 @@
+package dev.metabrix.urfu.oopbot.storage;
+
+import dev.metabrix.urfu.oopbot.storage.model.dialog.DialogState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Хранилище состояний диалогов.
+ * 
+ * @since 1.1.0
+ * @author metabrix
+ */
+public interface DialogStateStorage {
+    /**
+     * Возвращает состояние диалога для пользователя в чате.
+     *
+     * @param userId ID пользователя в хранилище
+     * @param chatId ID чата в хранилище
+     * @return состояние диалога или {@code null}, если состояние диалога не установлено
+     * @since 1.1.0
+     * @author metabrix
+     */
+    @Nullable DialogState get(int userId, int chatId);
+
+    /**
+     * Устанавливает состояние диалога для пользователя в чате.
+     *
+     * @param userId ID пользователя в хранилище
+     * @param chatId ID чата в хранилище
+     * @param dialogState состояние диалога
+     * @since 1.1.0
+     * @author metabrix
+     */
+    void set(
+        int userId,
+        int chatId,
+        @NotNull DialogState dialogState
+    );
+
+    /**
+     * Удаляет состояние диалога для пользователя в чате.
+     *
+     * @param userId ID пользователя в хранилище
+     * @param chatId ID чата в хранилище
+     * @since 1.1.0
+     * @author metabrix
+     */
+    void delete(int userId, int chatId);
+}

--- a/src/main/java/dev/metabrix/urfu/oopbot/storage/impl/mysql/MySQLDataStorage.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/storage/impl/mysql/MySQLDataStorage.java
@@ -1,10 +1,7 @@
 package dev.metabrix.urfu.oopbot.storage.impl.mysql;
 
 import dev.metabrix.urfu.oopbot.BotConfiguration;
-import dev.metabrix.urfu.oopbot.storage.ChatStorage;
-import dev.metabrix.urfu.oopbot.storage.DataStorage;
-import dev.metabrix.urfu.oopbot.storage.TaskStorage;
-import dev.metabrix.urfu.oopbot.storage.UserStorage;
+import dev.metabrix.urfu.oopbot.storage.*;
 import dev.metabrix.urfu.oopbot.storage.impl.sql.SQLConnectionPool;
 import dev.metabrix.urfu.oopbot.util.LogUtils;
 import java.sql.PreparedStatement;
@@ -24,6 +21,7 @@ public class MySQLDataStorage implements DataStorage {
     private final @NotNull UserStorage users;
     private final @NotNull ChatStorage chats;
     private final @NotNull TaskStorage tasks;
+    private final @NotNull DialogStateStorage dialogStates;
 
     public MySQLDataStorage(@NotNull BotConfiguration.DataStorage.MySQLConfiguration configuration) throws Exception {
         this.tables = new Tables(configuration.tablePrefix());
@@ -33,6 +31,7 @@ public class MySQLDataStorage implements DataStorage {
         this.users = new MySQLUserStorage(this.pool, this.tables);
         this.chats = new MySQLChatStorage(this.pool, this.tables);
         this.tasks = new MySQLTaskStorage(this.pool, this.tables);
+        this.dialogStates = new MySQLDialogStateStorage(this.pool, this.tables);
     }
 
     private void updateSchema() throws Exception {
@@ -105,6 +104,12 @@ public class MySQLDataStorage implements DataStorage {
     public @NotNull TaskStorage tasks() {
         checkNotClosed();
         return this.tasks;
+    }
+
+    @Override
+    public @NotNull DialogStateStorage dialogStates() {
+        checkNotClosed();
+        return this.dialogStates;
     }
 
     @Override

--- a/src/main/java/dev/metabrix/urfu/oopbot/storage/impl/mysql/MySQLDialogStateStorage.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/storage/impl/mysql/MySQLDialogStateStorage.java
@@ -1,0 +1,93 @@
+package dev.metabrix.urfu.oopbot.storage.impl.mysql;
+
+import dev.metabrix.urfu.oopbot.storage.DialogStateStorage;
+import dev.metabrix.urfu.oopbot.storage.impl.sql.SQLConnectionPool;
+import dev.metabrix.urfu.oopbot.storage.model.dialog.DialogState;
+import dev.metabrix.urfu.oopbot.storage.model.dialog.DialogStateType;
+import dev.metabrix.urfu.oopbot.util.LogUtils;
+import dev.metabrix.urfu.oopbot.util.exception.StorageException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+
+public class MySQLDialogStateStorage implements DialogStateStorage {
+    private static final @NotNull Logger LOGGER = LogUtils.getLogger();
+
+    private final @NotNull SQLConnectionPool pool;
+    private final @NotNull Tables tables;
+
+    MySQLDialogStateStorage(@NotNull SQLConnectionPool pool, @NotNull Tables tables) {
+        this.pool = pool;
+        this.tables = tables;
+    }
+
+    @Override
+    public @Nullable DialogState get(int userId, int chatId) {
+        try (PreparedStatement s = this.pool.getConnection().prepareStatement(
+            "SELECT * FROM " + this.tables.dialogStates() + " WHERE user_id = ? AND chat_id = ?"
+        )) {
+            s.setInt(1, userId);
+            s.setInt(2, chatId);
+
+            try (ResultSet rs = s.executeQuery()) {
+                if (rs.next()) {
+                    DialogStateType type = DialogStateType.byId(rs.getString("type"));
+                    if (type == null) {
+                        LOGGER.warn(
+                            "Encountered unknown dialog state type: {} for user ID {} and chat ID {}",
+                            rs.getString("type"), userId, chatId
+                        );
+                        return null;
+                    }
+
+                    JSONObject json = new JSONObject(rs.getString("data"));
+                    return type.deserializeFromJson(json);
+                } else {
+                    return null;
+                }
+            }
+        } catch (SQLException | JSONException ex) {
+            // JSONException is here, because the data is stored in a JSON column and malformed data cannot be there,
+            // so JSONException here would be an unexpected scenario
+            throw new StorageException(ex);
+        }
+    }
+
+    @Override
+    public void set(int userId, int chatId, @NotNull DialogState dialogState) {
+        try (PreparedStatement s = this.pool.getConnection().prepareStatement(
+            "INSERT INTO " + this.tables.dialogStates() + " (user_id, chat_id, type, data) VALUES (?, ?, ?, ?) " +
+                "ON DUPLICATE KEY UPDATE type = ?, data = ?"
+        )) {
+            String typeId = dialogState.type().getId();
+            String data = dialogState.toJson().toString();
+            s.setInt(1, userId);
+            s.setInt(2, chatId);
+            s.setString(3, typeId);
+            s.setString(4, data);
+            s.setString(5, typeId);
+            s.setString(6, data);
+            s.executeUpdate();
+        } catch (SQLException ex) {
+            throw new StorageException(ex);
+        }
+    }
+
+    @Override
+    public void delete(int userId, int chatId) {
+        try (PreparedStatement s = this.pool.getConnection().prepareStatement(
+            "DELETE FROM " + this.tables.dialogStates() + " WHERE user_id = ? AND chat_id = ?"
+        )) {
+            s.setInt(1, userId);
+            s.setInt(2, chatId);
+            s.executeUpdate();
+        } catch (SQLException ex) {
+            throw new StorageException(ex);
+        }
+    }
+}

--- a/src/main/java/dev/metabrix/urfu/oopbot/storage/impl/mysql/SchemaUpdate.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/storage/impl/mysql/SchemaUpdate.java
@@ -95,6 +95,31 @@ enum SchemaUpdate {
             s.executeUpdate();
         }
     }),
+    INTRODUCE_DIALOG_STATES((connection, tables, logger) -> {
+        logger.info("Creating table {}", tables.dialogStates());
+        try (PreparedStatement s = connection.prepareStatement(
+            "CREATE TABLE IF NOT EXISTS " + tables.dialogStates() + " (" +
+                "user_id INT NOT NULL, " +
+                "chat_id INT NOT NULL, " +
+                "type VARCHAR(64) NOT NULL, " +
+                "data JSON NOT NULL, " +
+                "PRIMARY KEY (user_id, chat_id), " +
+                "INDEX (type), " +
+                "CONSTRAINT fk_dialog_states_user_id__id FOREIGN KEY (user_id) REFERENCES " + tables.users() + " (id) ON DELETE RESTRICT ON UPDATE RESTRICT, " +
+                "CONSTRAINT fk_dialog_states_chat_id__id FOREIGN KEY (chat_id) REFERENCES " + tables.chats() + " (id) ON DELETE RESTRICT ON UPDATE RESTRICT" +
+                ")"
+        )) {
+            s.executeUpdate();
+        }
+
+        try (PreparedStatement s = connection.prepareStatement(
+            "INSERT INTO " + tables.version() + " (version, time) VALUES (?, ?)"
+        )) {
+            s.setInt(1, 1);
+            s.setTimestamp(2, Timestamp.from(Instant.now()));
+            s.executeUpdate();
+        }
+    })
     ;
 
     private static final @NotNull Logger LOGGER = LogUtils.getLogger();

--- a/src/main/java/dev/metabrix/urfu/oopbot/storage/impl/mysql/Tables.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/storage/impl/mysql/Tables.java
@@ -6,14 +6,16 @@ record Tables(
     @NotNull String version,
     @NotNull String users,
     @NotNull String chats,
-    @NotNull String tasks
+    @NotNull String tasks,
+    @NotNull String dialogStates
 ) {
     Tables(@NotNull String tablePrefix) {
         this(
             tablePrefix + "version",
             tablePrefix + "users",
             tablePrefix + "chats",
-            tablePrefix + "tasks"
+            tablePrefix + "tasks",
+            tablePrefix + "dialog_states"
         );
     }
 }

--- a/src/main/java/dev/metabrix/urfu/oopbot/storage/model/dialog/DialogState.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/storage/model/dialog/DialogState.java
@@ -1,0 +1,42 @@
+package dev.metabrix.urfu.oopbot.storage.model.dialog;
+
+import dev.metabrix.urfu.oopbot.BotApplication;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONObject;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Состояние диалога.
+ *
+ * @since 1.1.0
+ * @author metabrix
+ */
+public interface DialogState {
+    /**
+     * Обрабатывает сообщение для этого состояния диалога.
+     *
+     * @param application приложения бота
+     * @param update событие Telegram API
+     * @since 1.1.0
+     * @author metabrix
+     */
+    void handleMessage(@NotNull BotApplication application, @NotNull Update update);
+
+    /**
+     * Возвращает тип состояния диалога.
+     *
+     * @return тип состояния диалога
+     * @since 1.1.0
+     * @author metabrix
+     */
+    @NotNull DialogStateType type();
+
+    /**
+     * Сериализует данные состояния диалога в JSON-объект.
+     *
+     * @return JSON-объект данных этого состояния диалога
+     * @since 1.1.0
+     * @author metabrix
+     */
+    @NotNull JSONObject toJson();
+}

--- a/src/main/java/dev/metabrix/urfu/oopbot/storage/model/dialog/DialogStateType.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/storage/model/dialog/DialogStateType.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
@@ -53,6 +54,12 @@ public enum DialogStateType {
      */
     public @NotNull DialogState deserializeFromJson(@NotNull JSONObject json) {
         return this.jsonDeserializer.apply(json);
+    }
+
+    @Override
+    @Contract(pure = true)
+    public @NotNull String toString() {
+        return this.getId();
     }
 
     /**

--- a/src/main/java/dev/metabrix/urfu/oopbot/storage/model/dialog/DialogStateType.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/storage/model/dialog/DialogStateType.java
@@ -1,0 +1,69 @@
+package dev.metabrix.urfu.oopbot.storage.model.dialog;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
+
+/**
+ * Тип состояния диалога.
+ *
+ * @since 1.1.0
+ * @author metabrix
+ */
+public enum DialogStateType {
+    ;
+
+    private static final @NotNull Map<@NotNull String, @NotNull DialogStateType> BY_ID =
+        Arrays.stream(values()).collect(Collectors.toUnmodifiableMap(
+            DialogStateType::getId,
+            Function.identity()
+        ));
+
+    private final @NotNull String id;
+    private final @NotNull Function<@NotNull JSONObject, @NotNull DialogState> jsonDeserializer;
+
+    DialogStateType(@NotNull Function<@NotNull JSONObject, @NotNull DialogState> jsonDeserializer) {
+        this.id = this.name().toLowerCase(Locale.ROOT);
+        this.jsonDeserializer = jsonDeserializer;
+    }
+
+    /**
+     * Возвращает ID этого типа состояния диалога для использования в хранилище.
+     *
+     * @return строковой ID этого типа в snake_case
+     * @since 1.1.0
+     * @author metabrix
+     */
+    public @NotNull String getId() {
+        return this.id;
+    }
+
+    /**
+     * Десериализует состояние диалога этого типа из JSON-объекта.
+     *
+     * @param json JSON-объект данных состояния диалога
+     * @return состояние диалога
+     * @since 1.1.0
+     * @author metabrix
+     */
+    public @NotNull DialogState deserializeFromJson(@NotNull JSONObject json) {
+        return this.jsonDeserializer.apply(json);
+    }
+
+    /**
+     * Возвращает тип состояния диалога по его ID.
+     *
+     * @param id строковой ID типа состояния диалога
+     * @return тип состояния диалога или {@code null}, если такого типа нет
+     * @since 1.1.0
+     * @author metabrix
+     */
+    public static @Nullable DialogStateType byId(@NotNull String id) {
+        return BY_ID.get(id);
+    }
+}

--- a/src/main/java/dev/metabrix/urfu/oopbot/telegram/MessageUpdateContext.java
+++ b/src/main/java/dev/metabrix/urfu/oopbot/telegram/MessageUpdateContext.java
@@ -5,6 +5,7 @@ import dev.metabrix.urfu.oopbot.storage.ChatStorage;
 import dev.metabrix.urfu.oopbot.storage.UserStorage;
 import dev.metabrix.urfu.oopbot.storage.model.Chat;
 import dev.metabrix.urfu.oopbot.storage.model.User;
+import dev.metabrix.urfu.oopbot.storage.model.dialog.DialogState;
 import dev.metabrix.urfu.oopbot.util.exception.DuplicateObjectException;
 import java.time.Instant;
 import java.util.Objects;
@@ -28,6 +29,7 @@ public final class MessageUpdateContext {
 
     private @Nullable User cachedUser;
     private @Nullable Chat cachedChat;
+    private @Nullable DialogState cachedDialogState;
 
     /**
      * Создаёт новый контекст.
@@ -220,5 +222,26 @@ public final class MessageUpdateContext {
                 );
             }
         }
+    }
+
+    /**
+     * Возвращает состояние диалога.
+     *
+     * @return состояние диалога или {@code null}, если его нет
+     * @since 1.1.0
+     * @author metabrix
+     */
+    public @Nullable DialogState getDialogState() {
+        if (this.cachedDialogState != null) return this.cachedDialogState;
+
+        User user = this.getAndUpdateUserIfExists();
+        if (user == null) return null;
+
+        Chat chat = this.getChatIfExists();
+        if (chat == null) return null;
+
+        DialogState dialogState = this.application.getStorage().dialogStates().get(user.id(), chat.id());
+        this.cachedDialogState = dialogState;
+        return dialogState;
     }
 }

--- a/src/test/java/dev/metabrix/urfu/oopbot/storage/model/dialog/DialogStateTypeTest.java
+++ b/src/test/java/dev/metabrix/urfu/oopbot/storage/model/dialog/DialogStateTypeTest.java
@@ -1,0 +1,63 @@
+package dev.metabrix.urfu.oopbot.storage.model.dialog;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DialogStateTypeTest {
+    @ParameterizedTest
+    @MethodSource("sourceTestJsonSerialization")
+    @EnabledIf("enabledTestJsonSerialization")
+    public void testJsonSerialization(@NotNull DialogStateType type, @NotNull JSONObject expectedJson) {
+        // Act
+        DialogState state = type.deserializeFromJson(expectedJson);
+        JSONObject actualJson = state.toJson();
+
+        // Assert
+        assertEquals(expectedJson, actualJson);
+    }
+
+    private static @NotNull Stream<@NotNull Arguments> sourceTestJsonSerialization() {
+        return Stream.of(
+        );
+    }
+
+    private static boolean enabledTestJsonSerialization() {
+        return sourceTestJsonSerialization().findAny().isPresent();
+    }
+
+    @Test
+    public void testAllTypesHaveTests() {
+        // Arrange
+        Set<DialogStateType> expectedTypes = new HashSet<>(Arrays.asList(DialogStateType.values()));
+        Set<DialogStateType> actualTypes = sourceTestJsonSerialization()
+            .map(arguments -> arguments.get()[0])
+            .map(DialogStateType.class::cast)
+            .collect(Collectors.toCollection(HashSet::new));
+
+        // Act
+        List<DialogStateType> missingTypes = expectedTypes.stream()
+            .filter(type -> !actualTypes.contains(type))
+            .sorted()
+            .toList();
+
+        // Assert
+        Assertions.assertTrue(
+            missingTypes.isEmpty(),
+            () -> "Missing " + DialogStateType.class.getSimpleName() + " tests for " + missingTypes
+        );
+    }
+}


### PR DESCRIPTION
# Описание 

Добавляет возможность сохранять состояния диалогов:
- Состояния диалога хранятся по ключу `(user_id; chat_id)`
- Состояния диалога хранятся в `DialogStatesStorage`
- По умолчанию, если состояние диалога не установлено, бот слушает команды
- Если состояние диалога установлено, но приходит команда (необязательно существующая), текущее состояние диалога сбрасывается
- Типы состояний добавляются в `DialogStateType`, обработчики реализуют `DialogState`

# Задачи

- [x] Хранилище состояний диалогов и реализации на существующих типах хранилищ со скриптами миграции
- [x] Интеграция в процесс обработки событий Telegram
- [x] Кто-то сказал «тесты»?